### PR TITLE
Add globalObject option to webpack.config.js 

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = function(env, argv) {
                 name: '@moesol/inter-widget-communication',
                 type: 'umd',
             },
+            globalObject: 'this',
         },
 
         resolve: {


### PR DESCRIPTION
**Description:**

This PR addresses a runtime error occurring when importing the package. The error, "ReferenceError: self is not defined," is encountered due to the absence of the `globalObject` configuration in the webpack setup. The addition of `globalObject: 'this'` to the webpack configuration ensures proper execution without encountering this error.

**Issue:**

Attempting to import the package into a React project leads to a runtime error: "ReferenceError: self is not defined" (located at `/app/node_modules/@moesol/inter-widget-communication/build/index.js:1:256`).

![image](https://github.com/MoebiusSolutions/inter-widget-communication/assets/88676042/bbf7933a-74c1-49f5-b600-d53614b9fd3f)


**Changes Made:**

Added `globalObject: 'this'` to the webpack configuration (`webpack.config.js`). This will change references from `self` to `this`.

